### PR TITLE
Support resource creates for groups

### DIFF
--- a/examples/groups.tf
+++ b/examples/groups.tf
@@ -1,0 +1,13 @@
+# groups.tf
+#   Group example
+#
+# API reference:
+#   https://developer.zendesk.com/rest_api/docs/support/groups
+
+resource "zendesk_group" "support-group" {
+  name = "Support"
+}
+
+resource "zendesk_group" "developer-group" {
+  name = "Developer"
+}

--- a/zendesk/resource_zendesk_group.go
+++ b/zendesk/resource_zendesk_group.go
@@ -1,0 +1,60 @@
+package zendesk
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	client "github.com/nukosuke/go-zendesk/zendesk"
+)
+
+// https://developer.zendesk.com/rest_api/docs/support/groups
+func resourceZendeskGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceZendeskGroupCreate,
+		Read:   resourceZendeskGroupRead,
+		Update: resourceZendeskGroupUpdate,
+		Delete: resourceZendeskGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceZendeskGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	zd := meta.(*client.Client)
+	group := client.Group{
+		Name: d.Get("name").(string),
+	}
+
+	// Actual API request
+	group, err := zd.CreateGroup(group)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%d", group.ID))
+	return nil
+}
+
+func resourceZendeskGroupRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceZendeskGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceZendeskGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}


### PR DESCRIPTION
#19 
https://developer.zendesk.com/rest_api/docs/support/groups

This PR implements only creation. Rest of operations(Read, Update, Delete) will be done in other PRs.

CI failure
```
zendesk\resource_zendesk_group.go:36:11: undefined: zendesk.Group
zendesk\resource_zendesk_group.go:41:18: zd.CreateGroup undefined (type *zendesk.Client has no field or method CreateGroup)
```
go-zendesk@v0.0.0 does not suppoert group API. It's necessary to upgrade to v0.1.0.