### PR TITLE
Upgrade go version to 1.11.6 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ cache:
   - '%LocalAppData%\go-build'
   - '%GOPATH%\pkg\mod'
 
-stack: go 1.11
+stack: go 1.11.6
 
 install:
   - go mod download


### PR DESCRIPTION
close #76 

1.11 doesn't work to get packages which include symlink
So, I upgraded the version to 1.11.6