### PR TITLE
Remove go@master from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - "1.11.x"
   - "1.12.x"
-  - master
 
 env:
   - GO111MODULE=on
@@ -22,11 +21,6 @@ install:
 script:
   - go test -v ./...
   - goveralls -service=travis-ci
-
-matrix:
-  fast_finish: true
-  allow_failures:
-    - go: master
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,16 @@ script:
   - go test -v ./...
   - goveralls -service=travis-ci
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - go: master
+
 jobs:
   include:
     - stage: acceptance
       if: type != pull_request and branch = master
-      go:
-        - master
+      go: 1.12.x
       env:
         - GO111MODULE=on
         - TF_ACC=1


### PR DESCRIPTION
golang master is sometimes broken and its build job is the heaviest.
I think that we could ignore the failure on master.