### PR TITLE
Fix Renovate groups

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,18 @@
 {
-  "groupName": "all dependencies",
   "separateMajorMinor": false,
-  "groupSlug": "all",
   "packageRules": [
+    {
+      "packageNames": ["github.com/hashicorp/terraform"],
+      "groupName": "Terraform",
+      "groupSlug": "terraform"
+    },
     {
       "packagePatterns": [
         "*"
       ],
-      "groupName": "all dependencies",
-      "groupSlug": "all"
+      "excludePackageNames": ["github.com/hashicorp/terraform"],
+      "groupName": "Indirect Dependencies",
+      "groupSlug": "indirect"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
https://github.com/nukosuke/terraform-provider-zendesk/pull/154#issuecomment-499095545

devide "all" group into terraform and the rest of dependencies.