### PR TITLE
Support for complex trigger action values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,32 +1,16 @@
 module github.com/nukosuke/terraform-provider-zendesk
 
 require (
-	github.com/agext/levenshtein v1.2.2 // indirect
-	github.com/apparentlymart/go-cidr v1.0.0 // indirect
-	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.19.46 // indirect
-	github.com/blang/semver v0.0.0-20190414102917-ba2c2ddd8906 // indirect
 	github.com/golang/mock v1.3.1
-	github.com/hashicorp/go-getter v1.3.0 // indirect
-	github.com/hashicorp/go-hclog v0.9.2 // indirect
-	github.com/hashicorp/go-plugin v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/hcl2 v0.0.0-20190609194556-318e80eefe28 // indirect
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
-	github.com/hashicorp/terraform v0.11.14
-	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/mattn/go-isatty v0.0.8 // indirect
-	github.com/mitchellh/cli v1.0.0 // indirect
-	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
-	github.com/mitchellh/hashstructure v1.0.0 // indirect
+	github.com/hashicorp/terraform v0.12.11
+	github.com/hashicorp/terraform-plugin-sdk v1.2.0
+	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/nukosuke/go-zendesk v0.2.0
-	github.com/posener/complete v1.2.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/ulikunitz/xz v0.5.6 // indirect
-	golang.org/x/crypto v0.0.0-20190609194556-f99c8df09eb5 // indirect
-	golang.org/x/net v0.0.0-20190609194556-461777fb6f67 // indirect
-	golang.org/x/sys v0.0.0-20190609194556-301114b31cce // indirect
-	google.golang.org/appengine v1.6.1 // indirect
-	google.golang.org/genproto v0.0.0-20190609194556-eb0b1bdb6ae6 // indirect
+	golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d // indirect
+
 )
+

--- a/zendesk/resource_zendesk_trigger.go
+++ b/zendesk/resource_zendesk_trigger.go
@@ -206,12 +206,37 @@ func createTrigger(d identifiableGetterSetter, zd client.TriggerAPI) error {
 	return marshalTrigger(trg, d)
 }
 
-func readTrigger(d *schema.ResourceData, zd client.TriggerAPI) error {
-	return nil
+func readTrigger(d identifiableGetterSetter, zd client.TriggerAPI) error {
+	id, err := atoi64(d.Id())
+	if err != nil {
+		return err
+	}
+
+	trigger, err := zd.GetTrigger(id)
+	if err != nil {
+		return err
+	}
+
+	return marshalTrigger(trigger, d)
 }
 
 func updateTrigger(d identifiableGetterSetter, zd client.TriggerAPI) error {
-	return nil
+	trigger, err := unmarshalTrigger(d)
+	if err != nil {
+		return err
+	}
+
+	id, err := atoi64(d.Id())
+	if err != nil {
+		return err
+	}
+
+	trigger, err = zd.UpdateTrigger(id, trigger)
+	if err != nil {
+		return err
+	}
+
+	return marshalTrigger(trigger, d)
 }
 
 func deleteTrigger(d identifiable, zd client.TriggerAPI) error {

--- a/zendesk/resource_zendesk_trigger.go
+++ b/zendesk/resource_zendesk_trigger.go
@@ -10,12 +10,21 @@ import (
 // https://developer.zendesk.com/rest_api/docs/support/triggers
 func resourceZendeskTrigger() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceZendeskTriggerCreate,
-		Read:   resourceZendeskTriggerRead,
-		Update: resourceZendeskTriggerUpdate,
-		Delete: func(data *schema.ResourceData, i interface{}) error {
+		Create: func(d *schema.ResourceData, i interface{}) error {
 			zd := i.(client.TriggerAPI)
-			return resourceZendeskTriggerDelete(data, zd)
+			return createTrigger(d, zd)
+		},
+		Read: func(d *schema.ResourceData, i interface{}) error {
+			zd := i.(client.TriggerAPI)
+			return readTrigger(d, zd)
+		},
+		Update: func(d *schema.ResourceData, i interface{}) error {
+			zd := i.(client.TriggerAPI)
+			return updateTrigger(d, zd)
+		},
+		Delete: func(d *schema.ResourceData, i interface{}) error {
+			zd := i.(client.TriggerAPI)
+			return deleteTrigger(d, zd)
 		},
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -63,8 +72,7 @@ func resourceZendeskTrigger() *schema.Resource {
 	}
 }
 
-func resourceZendeskTriggerCreate(d *schema.ResourceData, meta interface{}) error {
-	zd := meta.(*client.Client)
+func createTrigger(d identifiableGetterSetter, zd client.TriggerAPI) error {
 	trg := client.Trigger{
 		Title:       d.Get("title").(string),
 		Active:      d.Get("active").(bool),
@@ -109,15 +117,15 @@ func resourceZendeskTriggerCreate(d *schema.ResourceData, meta interface{}) erro
 	return nil
 }
 
-func resourceZendeskTriggerRead(d *schema.ResourceData, meta interface{}) error {
+func readTrigger(d *schema.ResourceData, zd client.TriggerAPI) error {
 	return nil
 }
 
-func resourceZendeskTriggerUpdate(d *schema.ResourceData, meta interface{}) error {
+func updateTrigger(d identifiableGetterSetter, zd client.TriggerAPI) error {
 	return nil
 }
 
-func resourceZendeskTriggerDelete(d identifiable, zd client.TriggerAPI) error {
+func deleteTrigger(d identifiable, zd client.TriggerAPI) error {
 	id, err := atoi64(d.Id())
 	if err != nil {
 		return err

--- a/zendesk/resource_zendesk_trigger_test.go
+++ b/zendesk/resource_zendesk_trigger_test.go
@@ -4,8 +4,69 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/nukosuke/go-zendesk/zendesk"
 	"github.com/nukosuke/go-zendesk/zendesk/mock"
 )
+
+func TestMarshalTrigger(t *testing.T) {
+	expected := zendesk.Trigger{
+		Title:       "title",
+		Description: "blabla",
+		Active:      true,
+	}
+	m := &identifiableMapGetterSetter{
+		mapGetterSetter: mapGetterSetter{},
+	}
+
+	err := marshalTrigger(expected, m)
+	if err != nil {
+		t.Fatalf("Failed to marshal map %v", err)
+	}
+
+	v, ok := m.GetOk("title")
+	if !ok {
+		t.Fatal("Failed to get title value")
+	}
+	if v != expected.Title {
+		t.Fatalf("trigger had incorrect title value %v. should have been %v", v, expected.Title)
+	}
+
+	v, ok = m.GetOk("description")
+	if !ok {
+		t.Fatal("Failed to get description value")
+	}
+	if v != expected.Description {
+		t.Fatalf("trigger had incorrect description value %v. should have been %v", v, expected.Description)
+	}
+
+	v, ok = m.GetOk("active")
+	if !ok {
+		t.Fatal("Failed to get active value")
+	}
+	if v != expected.Active {
+		t.Fatalf("trigger had incorrect active value %v. should have been %v", v, expected.Active)
+	}
+}
+
+func TestUnmarshalTrigger(t *testing.T) {
+	m := &identifiableMapGetterSetter{
+		id: "100",
+		mapGetterSetter: mapGetterSetter{
+			"title":       "Auto reply",
+			"description": "reply automatically",
+			"active":      true,
+		},
+	}
+
+	trg, err := unmarshalTrigger(m)
+	if err != nil {
+		t.Fatalf("unmarshal returned an error: %v", err)
+	}
+
+	if v := m.Get("title"); trg.Title != v {
+		t.Fatalf("trigger had title value %v. should have been %v", trg.Title, v)
+	}
+}
 
 func TestDeleteTrigger(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/zendesk/resource_zendesk_trigger_test.go
+++ b/zendesk/resource_zendesk_trigger_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/nukosuke/go-zendesk/zendesk/mock"
 )
 
-func TestTriggerDelete(t *testing.T) {
+func TestDeleteTrigger(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	c := mock.NewClient(ctrl)
 	d := newIdentifiableGetterSetter()
@@ -15,7 +15,7 @@ func TestTriggerDelete(t *testing.T) {
 	d.SetId("1234")
 
 	c.EXPECT().DeleteTrigger(gomock.Eq(int64(1234))).Return(nil)
-	err := resourceZendeskTriggerDelete(d, c)
+	err := deleteTrigger(d, c)
 	if err != nil {
 		t.Fatalf("Got error from resource delete: %v", err)
 	}

--- a/zendesk/resource_zendesk_trigger_test.go
+++ b/zendesk/resource_zendesk_trigger_test.go
@@ -1,9 +1,13 @@
 package zendesk
 
 import (
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 	"github.com/nukosuke/go-zendesk/zendesk"
 	"github.com/nukosuke/go-zendesk/zendesk/mock"
 )
@@ -68,8 +72,53 @@ func TestUnmarshalTrigger(t *testing.T) {
 	}
 }
 
+func TestCreateTrigger(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m := mock.NewClient(ctrl)
+	i := newIdentifiableGetterSetter()
+	out := zendesk.Trigger{
+		ID:    12345,
+		Title: "trigger",
+	}
+
+	m.EXPECT().CreateTrigger(gomock.Any()).Return(out, nil)
+	if err := createTrigger(i, m); err != nil {
+		t.Fatal("CreateTrigger return an error")
+	}
+
+	if v := i.Id(); v != "12345" {
+		t.Fatalf("CreateTrigger did not set resource id. Id was %s", v)
+	}
+
+	if v := i.Get("title"); v != "trigger" {
+		t.Fatalf("CreateTrigger did not set resource title. title was %s", v)
+	}
+}
+
+func TestReadTrigger(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m := mock.NewClient(ctrl)
+	i := newIdentifiableGetterSetter()
+	i.SetId("12345")
+
+	expected := zendesk.Trigger{
+		Title:  "trigger",
+		Active: true,
+	}
+	m.EXPECT().GetTrigger(gomock.Eq(int64(12345))).Return(expected, nil)
+	if err := readTrigger(i, m); err != nil {
+		t.Fatalf("GetTrigger received an error when calling: %v", err)
+	}
+}
+
 func TestDeleteTrigger(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	c := mock.NewClient(ctrl)
 	d := newIdentifiableGetterSetter()
 
@@ -80,4 +129,55 @@ func TestDeleteTrigger(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Got error from resource delete: %v", err)
 	}
+}
+
+func testTriggerDestroyed(s *terraform.State) error {
+	client := testAccProvider.Meta().(zendesk.TriggerAPI)
+
+	for k, r := range s.RootModule().Resources {
+		if r.Type != "zendesk_trigger" {
+			continue
+		}
+
+		id, err := atoi64(r.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		_, err = client.GetTrigger(id)
+		if err != nil {
+			return fmt.Errorf("did not get error from zendesk when trying to fetch the destroyed trigger. resource name %s", k)
+		}
+
+		zdresp, ok := err.(zendesk.Error)
+		if !ok {
+			return fmt.Errorf("error %v cannot be asserted as a zendesk error", err)
+		}
+
+		if zdresp.Status() != http.StatusNotFound {
+			return fmt.Errorf("did not get a not found error after destroy. error was %v", zdresp)
+		}
+	}
+	return nil
+}
+
+func TestAccTriggerExample(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testTriggerDestroyed,
+		Steps: []resource.TestStep{
+			{
+				Config: readExampleConfig(t, "triggers.tf"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("zendesk_trigger.auto-reply-trigger", "title", "Auto Reply Trigger"),
+					resource.TestCheckResourceAttr("zendesk_trigger.auto-reply-trigger", "active", "true"),
+					resource.TestCheckResourceAttrSet("zendesk_trigger.auto-reply-trigger", "all"),
+					resource.TestCheckResourceAttrSet("zendesk_trigger.auto-reply-trigger", "action"),
+				),
+			},
+		},
+	})
 }

--- a/zendesk/resource_zendesk_trigger_test.go
+++ b/zendesk/resource_zendesk_trigger_test.go
@@ -115,6 +115,22 @@ func TestReadTrigger(t *testing.T) {
 	}
 }
 
+func TestUpdateTrigger(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	m := mock.NewClient(ctrl)
+	i := &identifiableMapGetterSetter{
+		id:              "12345",
+		mapGetterSetter: mapGetterSetter{},
+	}
+
+	m.EXPECT().UpdateTrigger(gomock.Eq(int64(12345)), gomock.Any()).Return(zendesk.Trigger{}, nil)
+	if err := updateTrigger(i, m); err != nil {
+		t.Fatalf("updateTrigger returned an error %v", err)
+	}
+}
+
 func TestDeleteTrigger(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/zendesk/resource_zendesk_trigger_test.go
+++ b/zendesk/resource_zendesk_trigger_test.go
@@ -161,7 +161,7 @@ func testTriggerDestroyed(s *terraform.State) error {
 		}
 
 		_, err = client.GetTrigger(id)
-		if err != nil {
+		if err == nil {
 			return fmt.Errorf("did not get error from zendesk when trying to fetch the destroyed trigger. resource name %s", k)
 		}
 


### PR DESCRIPTION
This PR builds on top of the currently unmerged #140, adding support for CRUD operations
on trigger actions with complex values (such as JSON payloads) commonly used in integrations
with e.g. Zapier, PagerDuty, JIRA etc.

The following now works:

trigger.tf:
```
resource "zendesk_trigger" "json-target" {
    title = "notification_target trigger with JSON payload"

    // ...

    action {
        field = "notification_target"
        value = jsonencode([
            "1234"
            data.template_file.payload.rendered
        ])
    }
}

data "template_file" "payload" {
    template = file("${path.module}/trigger_payload.json.tpl")
    vars = {
        // ...
    }
}
```

TODO:
- [ ] add tests