### PR TITLE
Support lookup of ticket fields by title

### DIFF
--- a/examples/ticket_fields.tf
+++ b/examples/ticket_fields.tf
@@ -55,27 +55,22 @@ resource "zendesk_ticket_field" "textarea-field" {
   type = "textarea"
 }
 
-variable "ASSIGNEE_TICKET_FIELD_ID" { type = "string" }
 data "zendesk_ticket_field" "assignee" {
-  id = "${var.ASSIGNEE_TICKET_FIELD_ID}"
+  title = "Assignee"
 }
 
-variable "GROUP_TICKET_FIELD_ID" { type = "string" }
 data "zendesk_ticket_field" "group" {
-  id = "${var.GROUP_TICKET_FIELD_ID}"
+  title = "Group"
 }
 
-variable "STATUS_TICKET_FIELD_ID" { type = "string" }
 data "zendesk_ticket_field" "status" {
-  id = "${var.STATUS_TICKET_FIELD_ID}"
+  title = "Status"
 }
 
-variable "SUBJECT_TICKET_FIELD_ID" { type = "string" }
 data "zendesk_ticket_field" "subject" {
-  id = "${var.SUBJECT_TICKET_FIELD_ID}"
+  title = "Subject"
 }
 
-variable "DESCRIPTION_TICKET_FIELD_ID" { type = "string" }
 data "zendesk_ticket_field" "description" {
-  id = "${var.DESCRIPTION_TICKET_FIELD_ID}"
+  title = "Description"
 }

--- a/go.mod
+++ b/go.mod
@@ -1,32 +1,15 @@
 module github.com/nukosuke/terraform-provider-zendesk
 
 require (
-	github.com/agext/levenshtein v1.2.2 // indirect
-	github.com/apparentlymart/go-cidr v1.0.0 // indirect
-	github.com/armon/go-radix v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.19.46 // indirect
-	github.com/blang/semver v0.0.0-20190414102917-ba2c2ddd8906 // indirect
 	github.com/golang/mock v1.3.1
-	github.com/hashicorp/go-getter v1.3.0 // indirect
-	github.com/hashicorp/go-hclog v0.9.2 // indirect
-	github.com/hashicorp/go-plugin v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/hashicorp/hcl2 v0.0.0-20190609194556-318e80eefe28 // indirect
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
-	github.com/hashicorp/terraform v0.11.14
-	github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d // indirect
-	github.com/mattn/go-isatty v0.0.8 // indirect
-	github.com/mitchellh/cli v1.0.0 // indirect
-	github.com/mitchellh/copystructure v1.0.0 // indirect
-	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
-	github.com/mitchellh/hashstructure v1.0.0 // indirect
+	github.com/hashicorp/terraform v0.12.11
+	github.com/hashicorp/terraform-plugin-sdk v1.2.0
+	github.com/mattn/go-isatty v0.0.7 // indirect
 	github.com/nukosuke/go-zendesk v0.2.0
-	github.com/posener/complete v1.2.1 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/ulikunitz/xz v0.5.6 // indirect
-	golang.org/x/crypto v0.0.0-20190609194556-f99c8df09eb5 // indirect
-	golang.org/x/net v0.0.0-20190609194556-461777fb6f67 // indirect
-	golang.org/x/sys v0.0.0-20190609194556-301114b31cce // indirect
-	google.golang.org/appengine v1.6.1 // indirect
-	google.golang.org/genproto v0.0.0-20190609194556-eb0b1bdb6ae6 // indirect
+	golang.org/x/build v0.0.0-20190111050920-041ab4dc3f9d // indirect
+
 )

--- a/zendesk/data_source_zendesk_ticket_field_test.go
+++ b/zendesk/data_source_zendesk_ticket_field_test.go
@@ -22,17 +22,27 @@ func TestTicketFieldDataSourceRead(t *testing.T) {
 	c := mock.NewClient(ctrl)
 
 	m := newIdentifiableGetterSetter()
-	id := int(1234)
-	m.Set("id", id)
+	title := "Subject"
+
+	err := m.Set("title", title)
+	if err != nil {
+		t.Fatalf("Read system field returned an error. %v", err)
+	}
 
 	out := zendesk.TicketField{
+		ID: 1234,
+		Title: "Subject",
 		URL: "foobar",
 	}
 
-	c.EXPECT().GetTicketField(gomock.Eq(int64(id))).Return(out, nil)
-	err := readTicketFieldDataSource(m, c)
+	c.EXPECT().GetTicketFields().Return([]zendesk.TicketField{out}, zendesk.Page{}, nil)
+	err = readTicketFieldDataSource(m, c)
 	if err != nil {
 		t.Fatalf("Read system field returned an error. %v", err)
+	}
+
+	if v, ok := m.GetOk("id"); !ok || v.(int64) != out.ID {
+		t.Fatalf("Read system field did not set ID field. Expected %v, Got %v", out.ID, v)
 	}
 
 	if v, ok := m.GetOk("url"); !ok || v.(string) != out.URL {


### PR DESCRIPTION
This makes the following possible (without needing to inject the ticket field id as a variable):

```
data "zendesk_ticket_field" "status" {
  title = "Status" 
}
```

`zendesk_ticket_field.status.id` can then be used where needed.