### PR TITLE
Bump support Go versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,9 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - 1.14.x
-          - 1.15.x
+          - 1.16.x
+          - 1.17.x
+          - 1.18.x
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Terraform provider for Zendesk
 ## Requirements
 
 - Terraform >= v0.12.7
-- Go >= v1.14 (only for build)
+- Go >= v1.16 (only for build)
 
 ## Installation
 


### PR DESCRIPTION
* Drop go1.14, go1.15

* Add go1.16~1.18